### PR TITLE
Update SplitsApi and SegmentsApi to be able to send a new request param (till)

### DIFF
--- a/Splitio-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
+++ b/Splitio-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
@@ -36,7 +36,7 @@ namespace Splitio_Tests.Integration_Tests
             var segmentCache = new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
             var splitParser = new InMemorySplitParser(new JSONFileSegmentFetcher($"{rootFilePath}segment_payed.json", segmentCache), segmentCache);
             var splitChangeFetcher = new JSONFileSplitChangeFetcher($"{rootFilePath}splits_staging.json");
-            var splitChangesResult = splitChangeFetcher.Fetch(-1);
+            var splitChangesResult = splitChangeFetcher.Fetch(-1, new FetchOptions());
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
             var gates = new InMemoryReadinessGatesCache();
             gates.SdkInternalReady();
@@ -63,7 +63,7 @@ namespace Splitio_Tests.Integration_Tests
             var segmentCache = new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
             var splitParser = new InMemorySplitParser(new JSONFileSegmentFetcher($"{rootFilePath}segment_payed.json", segmentCache), segmentCache);
             var splitChangeFetcher = new JSONFileSplitChangeFetcher($"{rootFilePath}splits_staging_4.json");
-            var splitChangesResult = splitChangeFetcher.Fetch(-1);
+            var splitChangesResult = splitChangeFetcher.Fetch(-1, new FetchOptions());
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
             var gates = new InMemoryReadinessGatesCache();
             gates.SdkInternalReady();

--- a/Splitio-tests/Integration Tests/SplitSdkApiClientTests.cs
+++ b/Splitio-tests/Integration Tests/SplitSdkApiClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Classes;
 using Splitio.Telemetry.Storages;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ namespace Splitio_Tests.Integration_Tests
             var SplitSdkApiClient = new SplitSdkApiClient("///PUT API KEY HERE///", headers, baseUrl, 10000, 10000, telemetryStorage);
 
             //Act
-            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1, new FetchOptions());
   
             //Assert
             Assert.IsTrue(result.Contains("splits"));            
@@ -48,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
             var SplitSdkApiClient = new SplitSdkApiClient(string.Empty, headers, baseUrl, 10000, 10000, telemetryStorage);
 
             //Act
-            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1, new FetchOptions());
 
             //Assert
             Assert.IsTrue(result == string.Empty);

--- a/Splitio-tests/Unit Tests/Common/SynchronizerTests.cs
+++ b/Splitio-tests/Unit Tests/Common/SynchronizerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Common;
 using Splitio.Services.Events.Interfaces;
@@ -101,7 +102,7 @@ namespace Splitio_Tests.Unit_Tests.Common
 
             // Assert.
             Thread.Sleep(2000);
-            _splitFetcher.Verify(mock => mock.FetchSplits(false), Times.Once);            
+            _splitFetcher.Verify(mock => mock.FetchSplits(It.IsAny<FetchOptions>()), Times.Once);            
             _segmentFetcher.Verify(mock => mock.FetchAll(), Times.Once);
             _gates.Verify(mock => mock.SdkInternalReady(), Times.Once);
         }
@@ -116,7 +117,7 @@ namespace Splitio_Tests.Unit_Tests.Common
             _synchronizer.SynchronizeSegment(segmentName);
 
             // Assert.
-            _segmentFetcher.Verify(mock => mock.Fetch(segmentName, true), Times.Once);
+            _segmentFetcher.Verify(mock => mock.Fetch(segmentName, It.IsAny<FetchOptions>()), Times.Once);
         }
 
         [TestMethod]
@@ -126,7 +127,7 @@ namespace Splitio_Tests.Unit_Tests.Common
             _synchronizer.SynchronizeSplits();
 
             // Assert.
-            _splitFetcher.Verify(mock => mock.FetchSplits(true), Times.Once);
+            _splitFetcher.Verify(mock => mock.FetchSplits(It.IsAny<FetchOptions>()), Times.Once);
             _segmentFetcher.Verify(mock => mock.FetchSegmentsIfNotExists(It.IsAny<IList<string>>()), Times.Once);
         }
     }

--- a/Splitio-tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
+++ b/Splitio-tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Classes;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
@@ -16,7 +17,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             //Arrange
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
@@ -31,7 +32,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             
             //Act
-            var result = await apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1, new FetchOptions());
 
             //Assert
             Assert.IsNotNull(result);
@@ -47,12 +48,12 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
         {
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Throws(new Exception());
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
            
             //Act
-            var result = await apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1, new FetchOptions());
 
             //Assert
             Assert.IsNull(result);

--- a/Splitio-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
+++ b/Splitio-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
@@ -37,7 +37,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             segmentFetcher.Start();
 
             apiClient
-                .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+                .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
                 .Returns(Task.FromResult(PayedSplitJson));
 
             // Act
@@ -62,7 +62,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var segmentFetcher = new SelfRefreshingSegmentFetcher(apiFetcher, gates.Object, 10, cache, 1, segmentTaskQueue, new TasksManager(wrapperAdapter), wrapperAdapter);
 
             apiClient
-                .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+                .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
                 .Returns(Task.FromResult(PayedSplitJson));
 
             gates
@@ -102,10 +102,10 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             cache.Verify(mock => mock.GetChangeNumber(segment2), Times.Once);
             cache.Verify(mock => mock.GetChangeNumber(segment3), Times.Exactly(2));
 
-            apiFetcher.Verify(mock => mock.Fetch(segment1, -1, false), Times.Once);
-            apiFetcher.Verify(mock => mock.Fetch(segment3, -1, false), Times.Once);
-            apiFetcher.Verify(mock => mock.Fetch(segment2, -1, false), Times.Never);
-            apiFetcher.Verify(mock => mock.Fetch(segment2, 30, false), Times.Never);
+            apiFetcher.Verify(mock => mock.Fetch(segment1, -1, It.IsAny<FetchOptions>()), Times.Once);
+            apiFetcher.Verify(mock => mock.Fetch(segment3, -1, It.IsAny<FetchOptions>()), Times.Once);
+            apiFetcher.Verify(mock => mock.Fetch(segment2, -1, It.IsAny<FetchOptions>()), Times.Never);
+            apiFetcher.Verify(mock => mock.Fetch(segment2, 30, It.IsAny<FetchOptions>()), Times.Never);
         }
     }
 }

--- a/Splitio-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
+++ b/Splitio-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
@@ -21,7 +21,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Throws(new Exception());
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments  = new ConcurrentDictionary<string, Segment>();
@@ -29,7 +29,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var segmentFetcher = new SelfRefreshingSegment("payed", apiFetcher, gates, cache);
             
             //Act
-            segmentFetcher.FetchSegment();
+            segmentFetcher.FetchSegment(new FetchOptions());
 
             //Assert
             Assert.AreEqual(0, segments.Count);
@@ -42,7 +42,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
@@ -60,7 +60,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var segmentFetcher = new SelfRefreshingSegment("payed", apiFetcher, gates, cache);
 
             //Act
-            segmentFetcher.FetchSegment();
+            segmentFetcher.FetchSegment(new FetchOptions());
 
             //Assert
             Assert.IsTrue(gates.AreSegmentsReady(1));
@@ -73,7 +73,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), false))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
@@ -91,7 +91,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var segmentFetcher = new SelfRefreshingSegment("payed", apiFetcher, gates, cache);
 
             //Act
-            segmentFetcher.FetchSegment();
+            segmentFetcher.FetchSegment(new FetchOptions());
 
             //Assert
             Assert.AreEqual(1, segments.Count);

--- a/Splitio-tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
+++ b/Splitio-tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
@@ -19,13 +19,13 @@ namespace Splitio_Tests.Unit_Tests
             //Arrange
             Mock<ISplitSdkApiClient> apiMock = new Mock<ISplitSdkApiClient>();
             apiMock
-                .Setup(x => x.FetchSplitChanges(-1, false))
+                .Setup(x => x.FetchSplitChanges(-1, It.IsAny<FetchOptions>()))
                 .Returns(Task.FromResult("{\"splits\": [ { \"trafficType\": \"user\", \"name\": \"Reset_Seed_UI\", \"seed\": 1552577712, \"status\": \"ACTIVE\", \"defaultTreatment\": \"off\", \"changeNumber\": 1469827821322, \"conditions\": [ { \"matcherGroup\": { \"combiner\": \"AND\", \"matchers\": [ { \"keySelector\": { \"trafficType\": \"user\", \"attribute\": null }, \"matcherType\": \"ALL_KEYS\", \"negate\": false, \"userDefinedSegmentMatcherData\": null, \"whitelistMatcherData\": null, \"unaryNumericMatcherData\": null, \"betweenMatcherData\": null } ] }, \"partitions\": [ { \"treatment\": \"on\", \"size\": 100 }, { \"treatment\": \"off\", \"size\": 0, \"addedField\": \"test\"  } ] } ] } ], \"since\": 1469817846929, \"till\": 1469827821322 }\r\n"));
 
             ApiSplitChangeFetcher apiSplitChangeFetcher = new ApiSplitChangeFetcher(apiMock.Object);
 
             //Act
-            var result = await apiSplitChangeFetcher.Fetch(-1);
+            var result = await apiSplitChangeFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsTrue(result != null);
@@ -38,7 +38,7 @@ namespace Splitio_Tests.Unit_Tests
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), false))
+            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'splits': [
                             {
@@ -88,7 +88,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = await apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsNotNull(result);
@@ -110,7 +110,7 @@ namespace Splitio_Tests.Unit_Tests
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), false))
+            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'splits': [
                             {
@@ -161,7 +161,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = await apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsNotNull(result);
@@ -175,7 +175,7 @@ namespace Splitio_Tests.Unit_Tests
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), false))
+            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'splits': [
                             {
@@ -226,7 +226,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = await apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsNotNull(result);
@@ -239,12 +239,12 @@ namespace Splitio_Tests.Unit_Tests
         {
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), false))
+            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Throws(new Exception());
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = await apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsNull(result);
@@ -256,7 +256,7 @@ namespace Splitio_Tests.Unit_Tests
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), false))
+            .Setup(x => x.FetchSplitChanges(It.IsAny<long>(), It.IsAny<FetchOptions>()))
             .Returns(Task.FromResult(@"{
                           'splits': [
                             {
@@ -312,7 +312,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = await apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1, new FetchOptions());
 
             //Assert
             Assert.IsNotNull(result);

--- a/src/Splitio/Domain/FetchOptions.cs
+++ b/src/Splitio/Domain/FetchOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Splitio.Domain
+{
+    public class FetchOptions
+    {
+        public long? Till { get; set; }
+        public bool CacheControlHeaders { get; set; }
+    }
+}

--- a/src/Splitio/Domain/SelfRefreshingConfig.cs
+++ b/src/Splitio/Domain/SelfRefreshingConfig.cs
@@ -20,6 +20,8 @@ namespace Splitio.Domain
         public IImpressionListener ImpressionListener { get; set; }
         public ImpressionsMode ImpressionsMode { get; set; }
         public long SdkStartTime { get; set; }
+        public int OnDemandFetchRetryDelayMs { get; set; }
+        public int OnDemandFetchMaxRetries { get; set; }
 
         // Urls.
         public string BaseUrl { get; set; }

--- a/src/Splitio/Services/Client/Classes/JSONFileClient.cs
+++ b/src/Splitio/Services/Client/Classes/JSONFileClient.cs
@@ -32,7 +32,7 @@ namespace Splitio.Services.Client.Classes
 
             var segmentFetcher = new JSONFileSegmentFetcher(segmentsFilePath, _segmentCache);
             var splitChangeFetcher = new JSONFileSplitChangeFetcher(splitsFilePath);
-            var task = splitChangeFetcher.Fetch(-1);
+            var task = splitChangeFetcher.Fetch(-1, new FetchOptions());
             task.Wait();
             
             var splitChangesResult = task.Result;

--- a/src/Splitio/Services/Common/Synchronizer.cs
+++ b/src/Splitio/Services/Common/Synchronizer.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Services.Cache.Interfaces;
+﻿using Splitio.Domain;
+using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Events.Interfaces;
 using Splitio.Services.Impressions.Interfaces;
 using Splitio.Services.Logger;
@@ -91,7 +92,7 @@ namespace Splitio.Services.Common
         {
             _tasksManager.Start(() =>
             {
-                _splitFetcher.FetchSplits().Wait();
+                _splitFetcher.FetchSplits(new FetchOptions()).Wait();
                 _segmentFetcher.FetchAll().Wait();
                 _gates.SdkInternalReady();
                 _log.Debug("Spltis and Segments synchronized...");
@@ -100,13 +101,13 @@ namespace Splitio.Services.Common
 
         public async Task SynchronizeSegment(string segmentName)
         {
-            await _segmentFetcher.Fetch(segmentName, cacheControlHeaders: true);
+            await _segmentFetcher.Fetch(segmentName, new FetchOptions { CacheControlHeaders = true });
             _log.Debug($"Segment fetched: {segmentName}...");
         }
 
         public async Task SynchronizeSplits()
         {
-            var segmentNames = await _splitFetcher.FetchSplits(cacheControlHeaders: true);
+            var segmentNames = await _splitFetcher.FetchSplits(new FetchOptions { CacheControlHeaders = true });
             await _segmentFetcher.FetchSegmentsIfNotExists(segmentNames);
             _log.Debug("Splits fetched...");
         }

--- a/src/Splitio/Services/EventSource/Workers/SegmentsWorker.cs
+++ b/src/Splitio/Services/EventSource/Workers/SegmentsWorker.cs
@@ -133,7 +133,7 @@ namespace Splitio.Services.EventSource.Workers
             }
             finally
             {
-                _log.Debug("Segments Workers excecute finished.");
+                _log.Debug("Segment Worker execution finished.");
             }
         }
         #endregion

--- a/src/Splitio/Services/EventSource/Workers/SplitsWorker.cs
+++ b/src/Splitio/Services/EventSource/Workers/SplitsWorker.cs
@@ -155,7 +155,7 @@ namespace Splitio.Services.EventSource.Workers
             }
             finally
             {
-                _log.Debug("Split Workers excecute finished.");
+                _log.Debug("Split Worker execution finished.");
             }
         }
         #endregion

--- a/src/Splitio/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
@@ -15,9 +15,9 @@ namespace Splitio.Services.SegmentFetcher.Classes
             _apiClient = apiClient;
         }
 
-        protected override async Task<SegmentChange> FetchFromBackend(string name, long since, bool cacheControlHeaders = false)
+        protected override async Task<SegmentChange> FetchFromBackend(string name, long since, FetchOptions fetchOptions)
         {
-            var fetchResult = await _apiClient.FetchSegmentChanges(name, since, cacheControlHeaders);
+            var fetchResult = await _apiClient.FetchSegmentChanges(name, since, fetchOptions);
 
             return JsonConvert.DeserializeObject<SegmentChange>(fetchResult);
         }

--- a/src/Splitio/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -11,13 +11,13 @@ namespace Splitio.Services.SegmentFetcher.Classes
     {
         private static readonly ISplitLogger _log = WrapperAdapter.GetLogger(typeof(SegmentChangeFetcher));
 
-        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since, bool cacheControlHeaders = false);
+        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since, FetchOptions fetchOptions);
 
-        public async Task<SegmentChange> Fetch(string name, long since, bool cacheControlHeaders = false)
+        public async Task<SegmentChange> Fetch(string name, long since, FetchOptions fetchOptions)
         {
             try
             {
-                return await FetchFromBackend(name, since, cacheControlHeaders);
+                return await FetchFromBackend(name, since, fetchOptions);
             }
             catch(Exception e)
             {

--- a/src/Splitio/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Services.Logger;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using Splitio.Services.Shared.Classes;
 using System;
@@ -57,7 +58,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                             if (!token.IsCancellationRequested)
                             {
                                 IncrementCounter();
-                                Task task = new Task(async () => await segment.FetchSegment(), token);
+                                Task task = new Task(async () => await segment.FetchSegment(new FetchOptions()), token);
                                 task.ContinueWith((x) => { DecrementCounter(); }, token);
                                 task.Start();
                             }

--- a/src/Splitio/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Services.Cache.Interfaces;
+﻿using Splitio.Domain;
+using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using Splitio.Services.Shared.Classes;
@@ -27,7 +28,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             _gates.RegisterSegment(name);
         }
 
-        public async Task FetchSegment(bool cacheControlHeaders = false)
+        public async Task FetchSegment(FetchOptions fetchOptions)
         {
             while (true)
             {
@@ -35,7 +36,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                 try
                 {
-                    var response = await _segmentChangeFetcher.Fetch(Name, changeNumber, cacheControlHeaders);
+                    var response = await _segmentChangeFetcher.Fetch(Name, changeNumber, fetchOptions);
 
                     if (response == null)
                     {

--- a/src/Splitio/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
@@ -1,4 +1,5 @@
 ﻿using Splitio.CommonLibraries;
+using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
@@ -46,7 +47,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             _gates = gates;
             _wrappedAdapter = wrapperAdapter;
             _segmentTaskQueue = segmentTaskQueue;
-            _tasksManager = tasksManager;            
+            _tasksManager = tasksManager;
         }
 
         #region Public Methods
@@ -129,19 +130,19 @@ namespace Splitio.Services.SegmentFetcher.Classes
         {
             foreach (var segment in _segments.Values)
             {
-                await segment.FetchSegment();
+                await segment.FetchSegment(new FetchOptions());
 
                 _log.Debug($"Segment fetched: {segment.Name}");
             }
         }
 
-        public async Task Fetch(string segmentName, bool cacheControlHeaders = false)
+        public async Task Fetch(string segmentName, FetchOptions fetchOptions)
         {
             try
             {
                 InitializeSegment(segmentName);
                 _segments.TryGetValue(segmentName, out SelfRefreshingSegment fetcher);
-                await fetcher.FetchSegment(cacheControlHeaders);
+                await fetcher.FetchSegment(fetchOptions);
             }
             catch (Exception ex)
             {
@@ -160,7 +161,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             {
                 var changeNumber = _segmentCache.GetChangeNumber(name);
 
-                if (changeNumber == -1) await Fetch(name);
+                if (changeNumber == -1) await Fetch(name, new FetchOptions());
             }
         }
         #endregion

--- a/src/Splitio/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
@@ -5,6 +5,6 @@ namespace Splitio.Services.SegmentFetcher.Interfaces
 {
     public interface ISegmentChangeFetcher
     {
-        Task<SegmentChange> Fetch(string name, long change_number, bool cacheControlHeaders = false);
+        Task<SegmentChange> Fetch(string name, long change_number, FetchOptions fetchOptions);
     }
 }

--- a/src/Splitio/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
+++ b/src/Splitio/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISegmentSdkApiClient
     {
-        Task<string> FetchSegmentChanges(string name, long since, bool cacheControlHeaders = false);
+        Task<string> FetchSegmentChanges(string name, long since, FetchOptions fetchOptions);
     }
 }

--- a/src/Splitio/Services/SegmentFetcher/Interfaces/ISelfRefreshingSegment.cs
+++ b/src/Splitio/Services/SegmentFetcher/Interfaces/ISelfRefreshingSegment.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Interfaces
 {
     public interface ISelfRefreshingSegment
     {
-        Task FetchSegment(bool cacheControlHeaders = false);
+        Task FetchSegment(FetchOptions fetchOptions);
     }
 }

--- a/src/Splitio/Services/SegmentFetcher/Interfaces/ISelfRefreshingSegmentFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Interfaces/ISelfRefreshingSegmentFetcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Splitio.Domain;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Interfaces
@@ -8,7 +9,7 @@ namespace Splitio.Services.SegmentFetcher.Interfaces
         void Start();
         void Stop();
         Task FetchAll();
-        Task Fetch(string segmentName, bool cacheControlHeaders = false);
+        Task Fetch(string segmentName, FetchOptions fetchOptions);
         Task FetchSegmentsIfNotExists(IList<string> names);
         void Clear();
     }

--- a/src/Splitio/Services/Shared/Classes/ConfigService.cs
+++ b/src/Splitio/Services/Shared/Classes/ConfigService.cs
@@ -76,7 +76,9 @@ namespace Splitio.Services.Shared.Classes
                 EventsBaseUrl = string.IsNullOrEmpty(config.EventsEndpoint) ? Constants.Urls.EventsBaseUrl : config.EventsEndpoint,
                 StreamingServiceURL = string.IsNullOrEmpty(config.StreamingServiceURL) ? Constants.Urls.StreamingServiceURL : config.StreamingServiceURL,
                 TelemetryServiceURL = string.IsNullOrEmpty(config.TelemetryServiceURL) ? Constants.Urls.TelemetryServiceURL : config.TelemetryServiceURL,
-                SdkStartTime = CurrentTimeHelper.CurrentTimeMillis()
+                SdkStartTime = CurrentTimeHelper.CurrentTimeMillis(),
+                OnDemandFetchMaxRetries = 10,
+                OnDemandFetchRetryDelayMs = 50
             };
 
             selfRefreshingConfig.TreatmentLogRefreshRate = GetImpressionRefreshRate(selfRefreshingConfig.ImpressionsMode, config.ImpressionsRefreshRate);

--- a/src/Splitio/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
@@ -14,9 +14,9 @@ namespace Splitio.Services.SplitFetcher.Classes
             _apiClient = apiClient;
         }
 
-        protected override async Task<SplitChangesResult> FetchFromBackend(long since, bool cacheControlHeaders = false)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since, FetchOptions fetchOptions)
         {
-            var fetchResult = await _apiClient.FetchSplitChanges(since, cacheControlHeaders);
+            var fetchResult = await _apiClient.FetchSplitChanges(since, fetchOptions);
 
             var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResult);
             return splitChangesResult;

--- a/src/Splitio/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
@@ -22,7 +22,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             _wrapperAdapter = new WrapperAdapter();
         }
 
-        protected override async Task<SplitChangesResult> FetchFromBackend(long since, bool cacheControlHeaders = false)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since, FetchOptions fetchOptions)
         {
             var json = File.ReadAllText(_filePath);
             var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(json);

--- a/src/Splitio/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -58,7 +58,7 @@ namespace Splitio.Services.SplitFetcher.Classes
 
                     _taskManager.StartPeriodic(() =>
                     {
-                        FetchSplits().Wait();
+                        FetchSplits(new FetchOptions()).Wait();
                     }, _interval * 1000, _cancelTokenSource, "Splits Fetcher.");
                 }
             }, new CancellationTokenSource(), "Main Splits Fetcher.");
@@ -81,7 +81,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             _splitCache.Clear();
         }
 
-        public async Task<IList<string>> FetchSplits(bool cacheControlHeaders = false)
+        public async Task<IList<string>> FetchSplits(FetchOptions fetchOptions)
         {
             var segmentNames = new List<string>();
             var names = new Dictionary<string, string>();
@@ -92,7 +92,7 @@ namespace Splitio.Services.SplitFetcher.Classes
 
                 try
                 {
-                    var result = await _splitChangeFetcher.Fetch(changeNumber, cacheControlHeaders);
+                    var result = await _splitChangeFetcher.Fetch(changeNumber, fetchOptions);
 
                     if (result == null)
                     {

--- a/src/Splitio/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
@@ -11,13 +11,13 @@ namespace Splitio.Services.SplitFetcher.Classes
     {
         private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SplitChangeFetcher));
 
-        protected abstract Task<SplitChangesResult> FetchFromBackend(long since, bool cacheControlHeaders = false);
+        protected abstract Task<SplitChangesResult> FetchFromBackend(long since, FetchOptions fetchOptions);
 
-        public async Task<SplitChangesResult> Fetch(long since, bool cacheControlHeaders = false)
+        public async Task<SplitChangesResult> Fetch(long since, FetchOptions fetchOptions)
         {
             try
             {
-                return await FetchFromBackend(since, cacheControlHeaders);
+                return await FetchFromBackend(since, fetchOptions);
             }
             catch(Exception e)
             {

--- a/src/Splitio/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
@@ -5,6 +5,6 @@ namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitChangeFetcher
     {
-        Task<SplitChangesResult> Fetch(long since, bool cacheControlHeaders = false);
+        Task<SplitChangesResult> Fetch(long since, FetchOptions fetchOptions);
     }
 }

--- a/src/Splitio/Services/SplitFetcher/Interfaces/ISplitFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Interfaces/ISplitFetcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Splitio.Domain;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
@@ -7,7 +8,7 @@ namespace Splitio.Services.SplitFetcher.Interfaces
     {
         void Start();
         void Stop();
-        Task<IList<string>> FetchSplits(bool cacheControlHeaders = false);
+        Task<IList<string>> FetchSplits(FetchOptions fetchOptions);
         void Clear();
     }
 }

--- a/src/Splitio/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
+++ b/src/Splitio/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitSdkApiClient
     {
-        Task<string> FetchSplitChanges(long since, bool cacheControlHeaders = false);
+        Task<string> FetchSplitChanges(long since, FetchOptions fetchOptions);
     }
 }


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
- Update SplitsApi and SegmentsApi to be able to send a new request param (till)