### PR TITLE
Renamed mtks to keys

### DIFF
--- a/Splitio-tests/Unit Tests/Telemetry/Common/TelemetryAPITests.cs
+++ b/Splitio-tests/Unit Tests/Telemetry/Common/TelemetryAPITests.cs
@@ -8,7 +8,6 @@ using Splitio.Telemetry.Common;
 using Splitio.Telemetry.Domain;
 using Splitio.Telemetry.Domain.Enums;
 using Splitio.Telemetry.Storages;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Splitio_Tests.Unit_Tests.Telemetry.Common
@@ -115,9 +114,9 @@ namespace Splitio_Tests.Unit_Tests.Telemetry.Common
 
             var uniqueKeys = new UniqueKeys(values);
 
-            var data = "{\"mtks\":[{\"f\":\"feature-01\",\"ks\":[\"key-01\",\"key-02\",\"key-03\",\"key-04\"]}]}";
+            var data = "{\"keys\":[{\"f\":\"feature-01\",\"ks\":[\"key-01\",\"key-02\",\"key-03\",\"key-04\"]}]}";
             _splitioHttpClient
-                .Setup(mock => mock.PostAsync("www.fake-url.com/mtks/ss", data))
+                .Setup(mock => mock.PostAsync("www.fake-url.com/keys/ss", data))
                 .ReturnsAsync(new HTTPResult
                 {
                     statusCode = System.Net.HttpStatusCode.OK
@@ -127,7 +126,7 @@ namespace Splitio_Tests.Unit_Tests.Telemetry.Common
             _telemetryAPI.RecordUniqueKeys(uniqueKeys);
 
             // Assert.
-            _splitioHttpClient.Verify(mock => mock.PostAsync("www.fake-url.com/mtks/ss", data), Times.Once);
+            _splitioHttpClient.Verify(mock => mock.PostAsync("www.fake-url.com/keys/ss", data), Times.Once);
             _log.Verify(mock => mock.Error(It.IsAny<string>()), Times.Never);
         }
     }

--- a/src/Splitio/Telemetry/Common/TelemetryAPI.cs
+++ b/src/Splitio/Telemetry/Common/TelemetryAPI.cs
@@ -15,7 +15,7 @@ namespace Splitio.Telemetry.Common
     {
         private const string ConfigURL = "/metrics/config";
         private const string UsageURL = "/metrics/usage";
-        private const string UniqueKeysURL = "/mtks/ss";
+        private const string UniqueKeysURL = "/keys/ss";
 
         private readonly ISplitioHttpClient _splitioHttpClient;
         private readonly ISplitLogger _log;

--- a/src/Splitio/Telemetry/Domain/UniqueKeys.cs
+++ b/src/Splitio/Telemetry/Domain/UniqueKeys.cs
@@ -5,12 +5,12 @@ namespace Splitio.Telemetry.Domain
 {
     public class UniqueKeys
     {
-        [JsonProperty("mtks")]
-        public List<Mtks> Mtks { get; }
+        [JsonProperty("keys")]
+        public List<Mtks> Keys { get; }
 
         public UniqueKeys(List<Mtks> values)
         {
-            Mtks = values;
+            Keys = values;
         }
     }
 


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
- Renamed `mtks` to `keys`