### PR TITLE
Deprecate old versions and Added new targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This SDK is designed to work with Split, the platform for controlled rollouts, w
 [![Twitter Follow](https://img.shields.io/twitter/follow/splitsoftware.svg?style=social&label=Follow&maxAge=1529000)](https://twitter.com/intent/follow?screen_name=splitsoftware)
  
 ## Compatibility
-This SDK is compatible with NET Framework 4.0 and above and NET Core 1.x, 2.x and 3.0.
+This SDK is compatible with:
+    - .NET Framework 4.5 and above
+    - .NET Core 2.x and 3.x
+    - .NET 5 and .NET 6
 
 ## Getting started
 Below is a simple example that describes the instantiation and most basic usage of our SDK:

--- a/Splitio-tests/Splitio-tests.csproj
+++ b/Splitio-tests/Splitio-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <RootNamespace>Splitio_Tests</RootNamespace>
   </PropertyGroup>
 
@@ -12,11 +12,11 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 	<ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj" />
     <ProjectReference Include="..\src\Splitio\Splitio.csproj" />
   </ItemGroup>

--- a/Splitio-tests/Splitio-tests.csproj
+++ b/Splitio-tests/Splitio-tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />

--- a/Splitio-tests/Splitio-tests.csproj
+++ b/Splitio-tests/Splitio-tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/Splitio-tests/Splitio-tests.csproj
+++ b/Splitio-tests/Splitio-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace>Splitio_Tests</RootNamespace>
   </PropertyGroup>
 
@@ -12,11 +12,11 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
 	<ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj" />
     <ProjectReference Include="..\src\Splitio\Splitio.csproj" />
   </ItemGroup>

--- a/Splitio-tests/Splitio-tests.csproj
+++ b/Splitio-tests/Splitio-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;netcoreapp1.0;net472;net471;net47;net462;net461;net46;net452;net451;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace>Splitio_Tests</RootNamespace>
   </PropertyGroup>
 
@@ -12,46 +12,21 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp1.1' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp2.2'">
-    <ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+	<ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj" />
     <ProjectReference Include="..\src\Splitio\Splitio.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj">
       <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\Splitio\Splitio.csproj">
       <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net451' or '$(TargetFramework)' == 'net45'">
-    <ProjectReference Include="..\Splitio.Redis\Splitio.Redis.csproj">
-      <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\src\Splitio\Splitio.csproj">
-      <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 

--- a/Splitio.Integration-tests/Splitio.Integration-tests.csproj
+++ b/Splitio.Integration-tests/Splitio.Integration-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace>Splitio.Integration_tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <PackageReference Include="WireMock.Net" Version="1.0.29" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
 

--- a/Splitio.Integration-tests/Splitio.Integration-tests.csproj
+++ b/Splitio.Integration-tests/Splitio.Integration-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace>Splitio.Integration_tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Splitio.Integration-tests/Splitio.Integration-tests.csproj
+++ b/Splitio.Integration-tests/Splitio.Integration-tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="WireMock.Net" Version="1.0.29" />
   </ItemGroup>
 

--- a/Splitio.Integration-tests/Splitio.Integration-tests.csproj
+++ b/Splitio.Integration-tests/Splitio.Integration-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <RootNamespace>Splitio.Integration_tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <PackageReference Include="WireMock.Net" Version="1.0.29" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
 

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Splitio.Redis</AssemblyName>
     <PackageId>Splitio.Redis</PackageId>
     <PackageTargetFallback Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
@@ -22,7 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
 

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;net40;net45;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Splitio.Redis</AssemblyName>
     <PackageId>Splitio.Redis</PackageId>
-    <PackageTargetFallback Condition="'$(TargetFramework)' != 'netstandard2.0'">
-      $(PackageTargetFallback);dnxcore50
+    <PackageTargetFallback Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
+		$(PackageTargetFallback);dnxcore50
     </PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -16,10 +16,6 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>SplitioRedis.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,17 +30,10 @@
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="StackExchange.Redis.StrongName" version="1.2.1" />
-    <PackageReference Include="Microsoft.Bcl" version="1.1.10" />
-    <PackageReference Include="Microsoft.Bcl.Async" version="1.0.168" />
-    <PackageReference Include="Microsoft.Bcl.Build" Version="1.0.14" />
-  </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\src\Splitio\Splitio.csproj" />
   </ItemGroup>

--- a/Splitio.TestSupport/Splitio.TestSupport.csproj
+++ b/Splitio.TestSupport/Splitio.TestSupport.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <Version>3.3.1</Version>
   </PropertyGroup>
 

--- a/Splitio.TestSupport/Splitio.TestSupport.csproj
+++ b/Splitio.TestSupport/Splitio.TestSupport.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;netcoreapp1.0;net472;net471;net47;net462;net461;net46;net452;net451;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Version>3.3.1</Version>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ after_build:
  - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release
  - Redis-64\tools\redis-server.exe --service-stop
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Releases
+ - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release
  - dotnet test .\Splitio.TestSupport\Splitio.TestSupport.csproj --configuration Release
  - dotnet pack .\src\Splitio --configuration Release
  - dotnet pack .\Splitio.Redis --configuration Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,16 +29,10 @@ after_build:
  - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release --framework netcoreapp2.2
  - Redis-64\tools\redis-server.exe --service-stop
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework netcoreapp2.2
- - Redis-64\tools\redis-server.exe --service-stop
- - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework net45
- - Redis-64\tools\redis-server.exe --service-stop
- - Redis-64\tools\redis-server.exe --service-start
  - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework net472
  - Redis-64\tools\redis-server.exe --service-stop
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework net462 
+ - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework netcoreapp2.2
  - dotnet test .\Splitio.TestSupport\Splitio.TestSupport.csproj --configuration Release
  - dotnet pack .\src\Splitio --configuration Release
  - dotnet pack .\Splitio.Redis --configuration Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2022
+
 nuget:
   account_feed: true
 
@@ -23,16 +26,10 @@ build_script:
 
 after_build:
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release --framework net472
+ - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release
  - Redis-64\tools\redis-server.exe --service-stop
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release --framework netcoreapp2.2
- - Redis-64\tools\redis-server.exe --service-stop
- - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework net472
- - Redis-64\tools\redis-server.exe --service-stop
- - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release --framework netcoreapp2.2
+ - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Releases
  - dotnet test .\Splitio.TestSupport\Splitio.TestSupport.csproj --configuration Release
  - dotnet pack .\src\Splitio --configuration Release
  - dotnet pack .\Splitio.Redis --configuration Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,10 @@ build_script:
 
 after_build:
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release
+ - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release
  - Redis-64\tools\redis-server.exe --service-stop
  - Redis-64\tools\redis-server.exe --service-start
- - dotnet test .\Splitio-tests\Splitio-tests.csproj --configuration Release
+ - dotnet test .\Splitio.Integration-tests\Splitio.Integration-tests.csproj --configuration Release
  - dotnet test .\Splitio.TestSupport\Splitio.TestSupport.csproj --configuration Release
  - dotnet pack .\src\Splitio --configuration Release
  - dotnet pack .\Splitio.Redis --configuration Release

--- a/src/Splitio/CommonLibraries/SdkApiClient.cs
+++ b/src/Splitio/CommonLibraries/SdkApiClient.cs
@@ -27,7 +27,7 @@ namespace Splitio.CommonLibraries
             long readTimeout,
             ITelemetryRuntimeProducer telemetryRuntimeProducer)
         {
-#if NET40 || NET45 || NET461
+#if NET45 || NET461
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
 #endif
             _telemetryRuntimeProducer = telemetryRuntimeProducer;

--- a/src/Splitio/Services/Common/SplitioHttpClient.cs
+++ b/src/Splitio/Services/Common/SplitioHttpClient.cs
@@ -31,7 +31,7 @@ namespace Splitio.Services.Common
             long connectionTimeOut,
             Dictionary<string, string> headers = null)
         {
-#if NET40 || NET45 || NET461
+#if NET45 || NET461
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)Constants.Http.ProtocolTypeTls12;
 #endif
             _log = WrapperAdapter.GetLogger(typeof(SplitioHttpClient));

--- a/src/Splitio/Services/Logger/CommonLogging.cs
+++ b/src/Splitio/Services/Logger/CommonLogging.cs
@@ -1,4 +1,4 @@
-﻿#if NET40 || NET45 || NET461
+﻿#if NET45 || NET461
 using Common.Logging;
 using System; 
 

--- a/src/Splitio/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -1,4 +1,4 @@
-﻿# if NETSTANDARD
+﻿#if NETSTANDARD2_0
 using Microsoft.Extensions.Logging;
 using System;
 

--- a/src/Splitio/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0 || NET5_0
 using Microsoft.Extensions.Logging;
 using System;
 

--- a/src/Splitio/Services/Logger/SplitLoggerFactoryExtensions.cs
+++ b/src/Splitio/Services/Logger/SplitLoggerFactoryExtensions.cs
@@ -1,4 +1,4 @@
-﻿# if NETSTANDARD
+﻿#if NETSTANDARD2_0
 namespace Microsoft.Extensions.Logging
 {
     public static class SplitLoggerFactoryExtensions

--- a/src/Splitio/Services/Logger/SplitLoggerFactoryExtensions.cs
+++ b/src/Splitio/Services/Logger/SplitLoggerFactoryExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0 || NET5_0
 namespace Microsoft.Extensions.Logging
 {
     public static class SplitLoggerFactoryExtensions

--- a/src/Splitio/Services/Shared/Classes/WrapperAdapter.cs
+++ b/src/Splitio/Services/Shared/Classes/WrapperAdapter.cs
@@ -22,7 +22,7 @@ namespace Splitio.Services.Shared.Classes
             var data = new ReadConfigData();
             var ipAddressesEnabled = config.IPAddressesEnabled ?? true;
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET6_0 || NET5_0
             data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();
 #else
             data.SdkVersion = ".NET-" + SplitSdkVersion();
@@ -73,7 +73,7 @@ namespace Splitio.Services.Shared.Classes
 
         private string SplitSdkVersion()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET6_0 || NET5_0
             return typeof(Split).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 #else
             return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
@@ -82,7 +82,7 @@ namespace Splitio.Services.Shared.Classes
 
         public static ISplitLogger GetLogger(Type type)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET6_0 || NET5_0
             return new MicrosoftExtensionsLogging(type);
 #else
             return new CommonLogging(type);
@@ -91,7 +91,7 @@ namespace Splitio.Services.Shared.Classes
 
         public static ISplitLogger GetLogger(string type)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET6_0 || NET5_0
             return new MicrosoftExtensionsLogging(type);
 #else
             return new CommonLogging(type);
@@ -127,7 +127,7 @@ namespace Splitio.Services.Shared.Classes
             {
                 try
                 {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET6_0 || NET5_0
                     var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
                     hostAddressesTask.Wait();
                     return config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();

--- a/src/Splitio/Services/Shared/Classes/WrapperAdapter.cs
+++ b/src/Splitio/Services/Shared/Classes/WrapperAdapter.cs
@@ -22,7 +22,7 @@ namespace Splitio.Services.Shared.Classes
             var data = new ReadConfigData();
             var ipAddressesEnabled = config.IPAddressesEnabled ?? true;
 
-#if NETSTANDARD
+#if NETSTANDARD2_0
             data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();
 #else
             data.SdkVersion = ".NET-" + SplitSdkVersion();
@@ -35,7 +35,6 @@ namespace Splitio.Services.Shared.Classes
 
         public void TaskWaitAndDispose(params Task[] tasks)
         {
-#if !NETSTANDARD1_6
             try
             {
                 foreach (var t in tasks)
@@ -50,48 +49,31 @@ namespace Splitio.Services.Shared.Classes
             {
                 _log.Debug(ex.Message);
             }
-#endif
         }
 
         public Task TaskDelay(int millisecondsDelay, CancellationToken cancellationToken)
         {
-#if NETSTANDARD || NET45 || NET461
             return Task.Delay(millisecondsDelay, cancellationToken);
-#else
-            return TaskEx.Delay(millisecondsDelay, cancellationToken);
-#endif
         }
 
         public Task TaskDelay(int millisecondsDelay)
         {
-#if NETSTANDARD || NET45 || NET461
             return Task.Delay(millisecondsDelay);
-#else
-            return TaskEx.Delay(millisecondsDelay);
-#endif
         }
 
         public Task<Task> WhenAny(params Task[] tasks)
         {
-#if NETSTANDARD || NET45 || NET461
-             return Task.WhenAny(tasks);
-#else
-            return TaskEx.WhenAny(tasks);
-#endif
+            return Task.WhenAny(tasks);
         }
 
         public async Task<T> TaskFromResult<T>(T result)
         {
-#if NETSTANDARD || NET45 || NET461
             return await Task.FromResult(result);
-#else
-            return await TaskEx.FromResult(result);
-#endif
         }
 
         private string SplitSdkVersion()
         {
-#if NETSTANDARD
+#if NETSTANDARD2_0
             return typeof(Split).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 #else
             return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
@@ -100,7 +82,7 @@ namespace Splitio.Services.Shared.Classes
 
         public static ISplitLogger GetLogger(Type type)
         {
-#if NETSTANDARD
+#if NETSTANDARD2_0
             return new MicrosoftExtensionsLogging(type);
 #else
             return new CommonLogging(type);
@@ -109,7 +91,7 @@ namespace Splitio.Services.Shared.Classes
 
         public static ISplitLogger GetLogger(string type)
         {
-#if NETSTANDARD
+#if NETSTANDARD2_0
             return new MicrosoftExtensionsLogging(type);
 #else
             return new CommonLogging(type);
@@ -145,7 +127,7 @@ namespace Splitio.Services.Shared.Classes
             {
                 try
                 {
-#if NETSTANDARD
+#if NETSTANDARD2_0
                     var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
                     hostAddressesTask.Wait();
                     return config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Splitio</AssemblyName>
     <PackageId>Splitio</PackageId>
 	<PackageTargetFallback Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
@@ -25,7 +25,7 @@
 	<PackageReference Include="murmurhash-signed" Version="1.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;net40;net45;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Splitio</AssemblyName>
     <PackageId>Splitio</PackageId>
-    <PackageTargetFallback Condition="'$(TargetFramework)' != 'netstandard2.0'">
-      $(PackageTargetFallback);dnxcore50
-    </PackageTargetFallback>
+	<PackageTargetFallback Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
+	  $(PackageTargetFallback);dnxcore50
+	</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -19,45 +19,22 @@
     <AssemblyOriginatorKeyFile>Splitio.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETSTANDARD</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="YamlDotNet" version="8.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="MurmurHash-net-core" Version="1.0.0" />
+	<PackageReference Include="murmurhash-signed" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="murmurhash-signed" Version="1.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Common.Logging" version="3.3.1" />
     <PackageReference Include="Common.Logging.Core" version="3.3.1" />
-    <PackageReference Include="murmurhash-signed" version="1.0.3" />
-  </ItemGroup>  
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
     <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="Microsoft.Net.Http" version="2.2.29" />
-    <PackageReference Include="Microsoft.Bcl" version="1.1.10" />
-    <PackageReference Include="Microsoft.Bcl.Async" version="1.0.168" />
-    <PackageReference Include="Microsoft.Bcl.Build" Version="1.0.14" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
- Removed net standard 1.6 and net framework 4.0 target frameworks.
- Added net 5.0 and net 6.0 target frameworks.
- Upgrade tests dependencies.