### PR TITLE
Updated to avoid forcing TLS1.2 when TLS1.3 is available

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+7.0.1 (Jul 21, 2022)
+- Updated to avoid forcing TLS1.2 when TLS1.3 is available when compiling in .NET Framework.
+
 7.0.0 (May 26, 2022)
 - BREAKING CHANGE: Deprecated support for .NET Framework 4.0 and .NET Core 1.x.
 - Updated redis command for config telemetry, using hset instead of rpush now.

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.1-rc{build}
+version: 7.0.1
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.0
+version: 7.0.1-rc{build}
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/src/Splitio/CommonLibraries/SdkApiClient.cs
+++ b/src/Splitio/CommonLibraries/SdkApiClient.cs
@@ -4,7 +4,6 @@ using Splitio.Telemetry.Domain.Enums;
 using Splitio.Telemetry.Storages;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -28,7 +27,7 @@ namespace Splitio.CommonLibraries
             ITelemetryRuntimeProducer telemetryRuntimeProducer)
         {
 #if NET45
-            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072 | (SecurityProtocolType)768 | SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072;
 #endif
             _telemetryRuntimeProducer = telemetryRuntimeProducer;
             var handler = new HttpClientHandler()

--- a/src/Splitio/CommonLibraries/SdkApiClient.cs
+++ b/src/Splitio/CommonLibraries/SdkApiClient.cs
@@ -27,8 +27,8 @@ namespace Splitio.CommonLibraries
             long readTimeout,
             ITelemetryRuntimeProducer telemetryRuntimeProducer)
         {
-#if NET45 || NET461
-            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+#if NET45
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072 | (SecurityProtocolType)768 | SecurityProtocolType.Tls;
 #endif
             _telemetryRuntimeProducer = telemetryRuntimeProducer;
             var handler = new HttpClientHandler()

--- a/src/Splitio/Constants/Constants.cs
+++ b/src/Splitio/Constants/Constants.cs
@@ -11,7 +11,6 @@
     public class Http
     {
         public static string Bearer => "Bearer";
-        public static int ProtocolTypeTls12 => 3072;
         public static string SplitSDKVersion => "SplitSDKVersion";
         public static string SplitSDKImpressionsMode => "SplitSDKImpressionsMode";
         public static string SplitSDKMachineName => "SplitSDKMachineName";

--- a/src/Splitio/Services/Common/SplitioHttpClient.cs
+++ b/src/Splitio/Services/Common/SplitioHttpClient.cs
@@ -31,8 +31,8 @@ namespace Splitio.Services.Common
             long connectionTimeOut,
             Dictionary<string, string> headers = null)
         {
-#if NET45 || NET461
-            ServicePointManager.SecurityProtocol = (SecurityProtocolType)Constants.Http.ProtocolTypeTls12;
+#if NET45
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072 | (SecurityProtocolType)768 | SecurityProtocolType.Tls;
 #endif
             _log = WrapperAdapter.GetLogger(typeof(SplitioHttpClient));
             _httpClient = new HttpClient()

--- a/src/Splitio/Services/Common/SplitioHttpClient.cs
+++ b/src/Splitio/Services/Common/SplitioHttpClient.cs
@@ -32,7 +32,7 @@ namespace Splitio.Services.Common
             Dictionary<string, string> headers = null)
         {
 #if NET45
-            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072 | (SecurityProtocolType)768 | SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)12288 | (SecurityProtocolType)3072;
 #endif
             _log = WrapperAdapter.GetLogger(typeof(SplitioHttpClient));
             _httpClient = new HttpClient()

--- a/src/Splitio/Services/EventSource/Workers/SegmentsWorker.cs
+++ b/src/Splitio/Services/EventSource/Workers/SegmentsWorker.cs
@@ -67,7 +67,7 @@ namespace Splitio.Services.EventSource.Workers
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Start: {ex.Message}");
+                    _log.Debug($"Start: {ex.Message}");
                 }
             }
         }
@@ -92,7 +92,7 @@ namespace Splitio.Services.EventSource.Workers
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Stop: {ex.Message}");
+                    _log.Debug($"Stop: {ex.Message}");
                 }
             }
         }
@@ -116,7 +116,7 @@ namespace Splitio.Services.EventSource.Workers
             }
             catch (Exception ex)
             {
-                _log.Error($"Execute: {ex.Message}");
+                _log.Debug($"Execute: {ex.Message}");
             }
             finally
             {

--- a/src/Splitio/Services/EventSource/Workers/SplitsWorker.cs
+++ b/src/Splitio/Services/EventSource/Workers/SplitsWorker.cs
@@ -93,7 +93,7 @@ namespace Splitio.Services.EventSource.Workers
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Start: {ex.Message}");
+                    _log.Debug($"Start: {ex.Message}");
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace Splitio.Services.EventSource.Workers
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Stop: {ex.Message}");
+                    _log.Debug($"Stop: {ex.Message}");
                 }
             }
         }
@@ -143,7 +143,7 @@ namespace Splitio.Services.EventSource.Workers
             }
             catch (Exception ex)
             {
-                _log.Error($"Execute: {ex.Message}");
+                _log.Debug($"Execute: {ex.Message}");
             }
             finally
             {

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <RootNamespace>Splitio</RootNamespace>    
   </PropertyGroup>
 


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
- Updated to avoid forcing TLS1.2 when TLS1.3 is available