### PR TITLE
Add functionality to specify a percentage of traffic that can be in the Split

### DIFF
--- a/Splitio-tests/Integration Tests/LocalhostClientTests.cs
+++ b/Splitio-tests/Integration Tests/LocalhostClientTests.cs
@@ -181,6 +181,9 @@ namespace Splitio_Tests.Integration_Tests
             result = client.GetTreatmentWithConfig("key_for_wl_2", "testing_split_off_with_config");
             Assert.AreEqual("off", result.Treatment);
             Assert.AreEqual("{\"color\": \"green\"}", result.Config);
+
+            result = client.GetTreatmentWithConfig("key_for_ws", "testing_split_with_size");
+            Assert.IsTrue(string.Equals(result.Treatment, "on") || string.Equals(result.Treatment, "off"));
         }
 
         [DeploymentItem(@"Resources\split.yml")]
@@ -252,6 +255,9 @@ namespace Splitio_Tests.Integration_Tests
             result = client.GetTreatmentWithConfig("key_for_wl_2", "testing_split_off_with_config");
             Assert.AreEqual("off", result.Treatment);
             Assert.AreEqual("{\"color\": \"green\"}", result.Config);
+
+            result = client.GetTreatmentWithConfig("key_for_ws", "testing_split_with_size");
+            Assert.IsTrue(string.Equals(result.Treatment, "on") || string.Equals(result.Treatment, "off"));
         }
 
         [DeploymentItem(@"Resources\split.yaml")]

--- a/Splitio-tests/Resources/split.yaml
+++ b/Splitio-tests/Resources/split.yaml
@@ -20,3 +20,10 @@
 - testing_split_off_with_config:
     treatment: "off"
     config: "{\"color\": \"green\"}"
+# Playing with size
+- testing_split_with_size:
+    treatment: "on"
+    size: 55
+- testing_split_with_size:
+    treatment: "off"
+    size: 45

--- a/Splitio-tests/Resources/split.yml
+++ b/Splitio-tests/Resources/split.yml
@@ -20,3 +20,10 @@
 - testing_split_off_with_config:
     treatment: "off"
     config: "{\"color\": \"green\"}"
+# Playing with size
+- testing_split_with_size:
+    treatment: "on"
+    size: 55
+- testing_split_with_size:
+    treatment: "off"
+    size: 45

--- a/Splitio-tests/Unit Tests/Client/SplitFactoryUnitTests.cs
+++ b/Splitio-tests/Unit Tests/Client/SplitFactoryUnitTests.cs
@@ -159,6 +159,7 @@ namespace Splitio_Tests.Unit_Tests.Client
                 "testing_split_only_wl",
                 "testing_split_with_wl",
                 "testing_split_off_with_config",
+                "testing_split_with_size",
             };
 
             var configurationOptions = new ConfigurationOptions
@@ -197,6 +198,7 @@ namespace Splitio_Tests.Unit_Tests.Client
                 "testing_split_only_wl",
                 "testing_split_with_wl",
                 "testing_split_off_with_config",
+                "testing_split_with_size",
             };
 
             var configurationOptions = new ConfigurationOptions

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.3</Version>
+    <Version>7.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.4</Version>
+    <Version>7.0.5</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.1</Version>
+    <Version>7.0.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.1
+version: 7.0.2
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.4
+version: 7.0.5
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.2
+version: 7.0.3
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 nuget:
   account_feed: true
 
-version: 7.0.3
+version: 7.0.4
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/src/Splitio/Services/Shared/Classes/AbstractLocalhostFileService.cs
+++ b/src/Splitio/Services/Shared/Classes/AbstractLocalhostFileService.cs
@@ -30,7 +30,7 @@ namespace Splitio.Services.Shared.Classes
             return split;
         }
 
-        protected ConditionWithLogic CreateCondition(string treatment, List<string> keys = null)
+        protected ConditionWithLogic CreateCondition(string treatment, List<string> keys = null, int size = 100)
         {
             if (keys != null)
             {
@@ -53,7 +53,7 @@ namespace Splitio.Services.Shared.Classes
                     {
                         new PartitionDefinition
                         {
-                            size = 100,
+                            size = size,
                             treatment = treatment
                         }
                     },
@@ -81,7 +81,7 @@ namespace Splitio.Services.Shared.Classes
                     {
                         new PartitionDefinition
                         {
-                            size = 100,
+                            size = size,
                             treatment = treatment
                         }
                     },

--- a/src/Splitio/Services/Shared/Classes/YamlLocalhostFileService.cs
+++ b/src/Splitio/Services/Shared/Classes/YamlLocalhostFileService.cs
@@ -80,7 +80,6 @@ namespace Splitio.Services.Shared.Classes
                                 splitToAdd.configurations.Add(conf.Key, conf.Value);
                         }
 
-                        //splitToAdd.conditions.AddRange(oldSplit.conditions); 
                         MergeConditions(splitToAdd, oldSplit);
 
                         splits.TryUpdate(splitName, splitToAdd, oldSplit);

--- a/src/Splitio/Services/Shared/Classes/YamlLocalhostFileService.cs
+++ b/src/Splitio/Services/Shared/Classes/YamlLocalhostFileService.cs
@@ -28,6 +28,7 @@ namespace Splitio.Services.Shared.Classes
 
                 object keyOrKeys;
                 string config;
+                int size = 100;
 
                 foreach (var children in sequenceNodes.Children)
                 {
@@ -37,6 +38,7 @@ namespace Splitio.Services.Shared.Classes
                     var treatment = mapping.Value["treatment"]?.ToString();
                     try { keyOrKeys = mapping.Value["keys"]; } catch { keyOrKeys = null; }
                     try { config = ((YamlScalarNode)mapping.Value["config"]).Value; } catch { config = null; }
+                    try { int.TryParse(((YamlScalarNode)mapping.Value["size"]).Value, out size); } catch { size = 100; }
 
                     List<string> keys = null;
                     var splitToAdd = CreateParsedSplit(splitName, Control, new List<ConditionWithLogic>());
@@ -59,7 +61,7 @@ namespace Splitio.Services.Shared.Classes
                         }
                     }
 
-                    splitToAdd.conditions.Add(CreateCondition(treatment, keys));
+                    splitToAdd.conditions.Add(CreateCondition(treatment, keys, size));
 
                     if (!string.IsNullOrEmpty(config))
                     {

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.4</Version>
+    <Version>7.0.5</Version>
     <RootNamespace>Splitio</RootNamespace>    
   </PropertyGroup>
 

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.1</Version>
+    <Version>7.0.2</Version>
     <RootNamespace>Splitio</RootNamespace>    
   </PropertyGroup>
 

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
     <RootNamespace>Splitio</RootNamespace>    
   </PropertyGroup>
 

--- a/src/Splitio/Splitio.csproj
+++ b/src/Splitio/Splitio.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>7.0.3</Version>
+    <Version>7.0.4</Version>
     <RootNamespace>Splitio</RootNamespace>    
   </PropertyGroup>
 


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
Now it is possible to set the percentage of traffic of a specific split in the yaml file using the node "size".

## How do we test the changes introduced in this PR?
Running the unit tests or setting the size in your yaml file and checking the percentage of traffic set for your split locally.

## Extra Notes
I followed the same pattern already used in the codebase, and I also added the new functionality in the `CreateCondition` method making sure that it will not break any current use of it since the new parameter is optional.