### PR TITLE
improve LocalhostClient to  better handle updates

### DIFF
--- a/Splitio.Redis/Services/Cache/Classes/RedisSplitCache.cs
+++ b/Splitio.Redis/Services/Cache/Classes/RedisSplitCache.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Splitio.Domain;
 using Splitio.Redis.Services.Cache.Interfaces;
 using Splitio.Services.Cache.Interfaces;
@@ -18,7 +19,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public RedisSplitCache(IRedisAdapter redisAdapter,
             ISplitParser splitParser,
-            string userPrefix = null) 
+            string userPrefix = null)
             : base(redisAdapter, userPrefix)
         {
             _splitParser = splitParser;
@@ -29,7 +30,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             var key = $"{RedisKeyPrefix}{splitsKeyPrefix}till";
             var changeNumberString = _redisAdapter.Get(key);
             var result = long.TryParse(changeNumberString, out long changeNumberParsed);
-            
+
             return result ? changeNumberParsed : -1;
         }
 
@@ -62,7 +63,7 @@ namespace Splitio.Redis.Services.Cache.Classes
                     .Where(s => s != null)
                     .ToList();
             }
-            
+
             return new List<ParsedSplit>();
         }
 
@@ -138,7 +139,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             {
                 redisKey.Add($"{RedisKeyPrefix}{splitKeyPrefix}{name}");
             }
-                        
+
             var splitValues = _redisAdapter.MGet(redisKey.ToArray());
 
             if (splitValues == null || !splitValues.Any()) return new List<ParsedSplit>();
@@ -168,6 +169,10 @@ namespace Splitio.Redis.Services.Cache.Classes
         {
             return 0; // No-op
         }
+
+        public void Update(Dictionary<string, ParsedSplit> newSplits)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }
- 

--- a/src/Splitio/Services/Cache/Classes/InMemorySplitCache.cs
+++ b/src/Splitio/Services/Cache/Classes/InMemorySplitCache.cs
@@ -48,7 +48,7 @@ namespace Splitio.Services.Cache.Classes
             }
 
             _splits.AddOrUpdate(splitName, parsedSplit, (key, oldValue) => parsedSplit);
-            
+
             IncreaseTrafficTypeCount(parsedSplit?.trafficTypeName);
 
             return exists;
@@ -65,13 +65,13 @@ namespace Splitio.Services.Cache.Classes
         }
 
         public bool RemoveSplit(string splitName)
-        {            
+        {
             var removed = _splits.TryRemove(splitName, out ParsedSplit removedSplit);
 
             if (removed)
             {
                 DecreaseTrafficTypeCount(removedSplit);
-            }            
+            }
 
             return removed;
         }
@@ -99,7 +99,7 @@ namespace Splitio.Services.Cache.Classes
         }
 
         public List<ParsedSplit> GetAllSplits()
-        {            
+        {
             return _splits
                 .Values
                 .Where(s => s != null)
@@ -108,7 +108,7 @@ namespace Splitio.Services.Cache.Classes
 
         public void Clear()
         {
-            _splits.Clear();            
+            _splits.Clear();
             _trafficTypes.Clear();
         }
 
@@ -129,7 +129,7 @@ namespace Splitio.Services.Cache.Classes
         private void DecreaseTrafficTypeCount(ParsedSplit split)
         {
             if (split == null || string.IsNullOrEmpty(split.trafficTypeName)) return;
-            
+
             if (_trafficTypes.TryGetValue(split.trafficTypeName, out int quantity))
             {
                 if (quantity <= 1)
@@ -183,6 +183,23 @@ namespace Splitio.Services.Cache.Classes
         public int SplitsCount()
         {
             return GetSplitNames().Count;
+        }
+
+        public void Update(Dictionary<string, ParsedSplit> newSplits)
+        {
+            var keysToRemove = _splits.Keys.Except(newSplits.Keys).ToArray();
+            foreach (var key in keysToRemove)
+            {
+                _splits.TryRemove(key, out ParsedSplit removedSplit);
+            }
+
+            foreach (var newSplit in newSplits)
+            {
+                if (newSplit.Value != null)
+                {
+                    _splits.AddOrUpdate(newSplit.Key, newSplit.Value, (key, oldValue) => newSplit.Value);
+                }
+            }
         }
     }
 }

--- a/src/Splitio/Services/Cache/Interfaces/ISplitCache.cs
+++ b/src/Splitio/Services/Cache/Interfaces/ISplitCache.cs
@@ -18,5 +18,6 @@ namespace Splitio.Services.Cache.Interfaces
         void Kill(long changeNumber, string splitName, string defaultTreatment);
         List<string> GetSplitNames();
         int SplitsCount();
+        void Update(Dictionary<string, ParsedSplit> newSplits);
     }
 }

--- a/src/Splitio/Services/Client/Classes/LocalhostClient.cs
+++ b/src/Splitio/Services/Client/Classes/LocalhostClient.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Splitio.Services.Client.Classes
 {
@@ -16,7 +17,7 @@ namespace Splitio.Services.Client.Classes
         private const string DefaultSplitFileName = ".split";
         private const string SplitFileYml = ".yml";
         private const string SplitFileYaml = ".yaml";
-        
+
         private ILocalhostFileService _localhostFileService;
 
         private readonly FileSystemWatcher _watcher;
@@ -86,16 +87,7 @@ namespace Splitio.Services.Client.Classes
         private void OnFileChanged(object sender, FileSystemEventArgs e)
         {
             var splits = ParseSplitFile(_fullPath);
-
-            _splitCache.Clear();
-
-            foreach (var split in splits)
-            {
-                if (split.Value != null)
-                {
-                    _splitCache.AddSplit(split.Key, split.Value);
-                }
-            }
+            _splitCache.Update(splits.ToDictionary(x => x.Key, x => x.Value));
         }
 
         private string LookupFilePath(string filePath)


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
The current implementation cleans split cache completely for LocalhostClient on every file update before re-populating it.
This makes it hard to use when running integration tests in parallel.
This change makes updates of the cache less destructive.

## How do we test the changes introduced in this PR?
No functional changes, updates of the split file should update the cache as before

## Extra Notes