### PR TITLE
Add serializer settings

### DIFF
--- a/Splitio.Redis/Common/SerializerSettings.cs
+++ b/Splitio.Redis/Common/SerializerSettings.cs
@@ -1,0 +1,9 @@
+using Newtonsoft.Json;
+
+namespace Splitio.Redis.Common
+{
+    static class SerializerSettings
+    {
+        public static JsonSerializerSettings DefaultSerializerSettings { get; } = new JsonSerializerSettings();
+    }
+}

--- a/Splitio.Redis/Services/Cache/Classes/RedisEventsCache.cs
+++ b/Splitio.Redis/Services/Cache/Classes/RedisEventsCache.cs
@@ -6,6 +6,8 @@ using Splitio.Services.Shared.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Splitio.Redis.Common;
+using Splitio.Redis.Services.Common;
 
 namespace Splitio.Redis.Services.Cache.Classes
 {
@@ -38,7 +40,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             {
                 m = new { s = SdkVersion, i = MachineIp, n = MachineName },
                 e = wEvent.Event
-            });
+            }, SerializerSettings.DefaultSerializerSettings);
         }
     }
 }

--- a/Splitio.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
+++ b/Splitio.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Splitio.Redis.Common;
+using Splitio.Redis.Services.Common;
 
 namespace Splitio.Redis.Services.Cache.Classes
 {
@@ -55,7 +57,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             var lengthRedis = 0L;
             foreach (var item in uniqueKeys)
             {
-                lengthRedis = await _redisAdapterProducer.ListRightPushAsync(UniqueKeysKey, JsonConvert.SerializeObject(item));
+                lengthRedis = await _redisAdapterProducer.ListRightPushAsync(UniqueKeysKey, JsonConvert.SerializeObject(item, SerializerSettings.DefaultSerializerSettings));
             }
 
             // This operation will simply do nothing if the key no longer exists (queue is empty)
@@ -84,7 +86,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             {
                 m = new { s = SdkVersion, i = MachineIp, n = MachineName },
                 i = new { k = item.keyName, b = item.bucketingKey, f = item.feature, t = item.treatment, r = item.label, c = item.changeNumber, m = item.time, pt = item.previousTime }
-            }));
+            }, SerializerSettings.DefaultSerializerSettings));
 
             return impressions
                 .Select(i => (RedisValue)i)

--- a/Splitio.Redis/Services/Cache/Classes/RedisRuleBasedSegmentCache.cs
+++ b/Splitio.Redis/Services/Cache/Classes/RedisRuleBasedSegmentCache.cs
@@ -6,6 +6,8 @@ using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Parsing.Interfaces;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Splitio.Redis.Common;
+using Splitio.Redis.Services.Common;
 
 namespace Splitio.Redis.Services.Cache.Classes
 {
@@ -57,7 +59,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             if (string.IsNullOrEmpty(rbsJSON))
                 return null;
 
-            var rbsDto = JsonConvert.DeserializeObject<RuleBasedSegmentDto>(rbsJSON);
+            var rbsDto = JsonConvert.DeserializeObject<RuleBasedSegmentDto>(rbsJSON, SerializerSettings.DefaultSerializerSettings);
 
             return _rbsParser.Parse(rbsDto, this);
         }

--- a/Splitio.Redis/Services/Cache/Classes/RedisSplitCache.cs
+++ b/Splitio.Redis/Services/Cache/Classes/RedisSplitCache.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Splitio.Redis.Common;
+using Splitio.Redis.Services.Common;
 
 namespace Splitio.Redis.Services.Cache.Classes
 {
@@ -50,7 +52,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             if (string.IsNullOrEmpty(splitJson))
                 return null;
 
-            var split = JsonConvert.DeserializeObject<Split>(splitJson);
+            var split = JsonConvert.DeserializeObject<Split>(splitJson, SerializerSettings.DefaultSerializerSettings);
 
             return _splitParser.Parse(split, _ruleBasedSegmentCache);
         }
@@ -66,7 +68,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var splits = splitValues
                 .Where(x => !x.IsNull)
-                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s), _ruleBasedSegmentCache));
+                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s, SerializerSettings.DefaultSerializerSettings), _ruleBasedSegmentCache));
 
             return splits
                 .Where(s => s != null)
@@ -103,7 +105,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var splits = splitValues
                 .Where(s => !s.IsNull)
-                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s), _ruleBasedSegmentCache));
+                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s, SerializerSettings.DefaultSerializerSettings), _ruleBasedSegmentCache));
 
             return splits
                 .Where(s => s != null)
@@ -155,7 +157,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var splits = splitValues
                 .Where(s => !s.IsNull)
-                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s), _ruleBasedSegmentCache));
+                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s, SerializerSettings.DefaultSerializerSettings), _ruleBasedSegmentCache));
 
             return splits
                 .Where(s => s != null)
@@ -172,7 +174,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var splits = splitValues
                 .Where(x => !x.IsNull)
-                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s), _ruleBasedSegmentCache));
+                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s, SerializerSettings.DefaultSerializerSettings), _ruleBasedSegmentCache));
 
             return splits
                 .Where(s => s != null)
@@ -186,7 +188,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             if (string.IsNullOrEmpty(splitJson)) return null;
 
-            var split = JsonConvert.DeserializeObject<Split>(splitJson);
+            var split = JsonConvert.DeserializeObject<Split>(splitJson, SerializerSettings.DefaultSerializerSettings);
 
             return _splitParser.Parse(split, _ruleBasedSegmentCache);
         }

--- a/Splitio.Redis/Telemetry/Storages/RedisTelemetryStorage.cs
+++ b/Splitio.Redis/Telemetry/Storages/RedisTelemetryStorage.cs
@@ -6,6 +6,7 @@ using Splitio.Telemetry.Domain;
 using Splitio.Telemetry.Domain.Enums;
 using Splitio.Telemetry.Storages;
 using System.Threading.Tasks;
+using Splitio.Redis.Common;
 
 namespace Splitio.Redis.Telemetry.Storages
 {
@@ -28,7 +29,7 @@ namespace Splitio.Redis.Telemetry.Storages
             {
                 t = new { oM = config.OperationMode, st = config.Storage, aF = config.ActiveFactories, rF = config.RedundantActiveFactories, t = config.Tags },
                 m = new { i = MachineIp, n = MachineName, s = SdkVersion }
-            });
+            }, SerializerSettings.DefaultSerializerSettings);
 
             await _redisAdapterProducer.HashSetAsync(TelemetryInitKey, $"{SdkVersion}/{MachineName}/{MachineIp}", jsonData);
         }

--- a/src/Splitio/Common/SerializerSettings.cs
+++ b/src/Splitio/Common/SerializerSettings.cs
@@ -1,0 +1,9 @@
+using Newtonsoft.Json;
+
+namespace Splitio.Common
+{
+    static class SerializerSettings
+    {
+        public static JsonSerializerSettings DefaultSerializerSettings { get; } = new JsonSerializerSettings();
+    }
+}

--- a/src/Splitio/Services/Common/AuthApiClient.cs
+++ b/src/Splitio/Services/Common/AuthApiClient.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Splitio.Common;
 
 namespace Splitio.Services.Common
 {
@@ -71,14 +72,14 @@ namespace Splitio.Services.Common
         #region Private Methods
         private AuthenticationResponse GetSuccessResponse(string content)
         {
-            var authResponse = JsonConvert.DeserializeObject<AuthenticationResponse>(content);
+            var authResponse = JsonConvert.DeserializeObject<AuthenticationResponse>(content, SerializerSettings.DefaultSerializerSettings);
             authResponse.Retry = authResponse.PushEnabled;
 
             if (authResponse.PushEnabled == false) 
                 return authResponse;
 
             var tokenDecoded = DecodeJwt(authResponse.Token);
-            var token = JsonConvert.DeserializeObject<Jwt>(tokenDecoded);
+            var token = JsonConvert.DeserializeObject<Jwt>(tokenDecoded, SerializerSettings.DefaultSerializerSettings);
 
             authResponse.Channels = GetChannels(token);
             authResponse.Expiration = GetExpirationSeconds(token);
@@ -90,7 +91,7 @@ namespace Splitio.Services.Common
 
         private static string GetChannels(Jwt token)
         {
-            var capability = (JObject)JsonConvert.DeserializeObject(token.Capability);
+            var capability = (JObject)JsonConvert.DeserializeObject(token.Capability, SerializerSettings.DefaultSerializerSettings);
             var channelsList = capability
                 .Children()
                 .Select(c => c.First.Path)

--- a/src/Splitio/Services/EventSource/NotificationParser.cs
+++ b/src/Splitio/Services/EventSource/NotificationParser.cs
@@ -5,6 +5,8 @@ using Splitio.Services.Shared.Classes;
 using Splitio.Util;
 using System;
 using System.Text;
+using Splitio.Common;
+using Splitio.Services.Common;
 
 namespace Splitio.Services.EventSource
 {
@@ -46,26 +48,26 @@ namespace Splitio.Services.EventSource
         private IncomingNotification ParseMessage(string notificationString)
         {
             var notificationData = GetNotificationData<NotificationData>(notificationString);
-            var data = JsonConvert.DeserializeObject<IncomingNotification>(notificationData.Data);
+            var data = JsonConvert.DeserializeObject<IncomingNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
 
             IncomingNotification result;
             switch (data?.Type)
             {
                 case NotificationType.SPLIT_UPDATE:
-                    var sNotification = JsonConvert.DeserializeObject<SplitChangeNotification>(notificationData.Data);
+                    var sNotification = JsonConvert.DeserializeObject<SplitChangeNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
                     sNotification.FeatureFlag = DecompressData<Split>(sNotification);
                     result = sNotification;
                     break;
                 case NotificationType.RB_SEGMENT_UPDATE:
-                    var rbNotification = JsonConvert.DeserializeObject<RuleBasedSegmentNotification>(notificationData.Data);
+                    var rbNotification = JsonConvert.DeserializeObject<RuleBasedSegmentNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
                     rbNotification.RuleBasedSegmentDto = DecompressData<RuleBasedSegmentDto>(rbNotification);
                     result = rbNotification;
                     break;
                 case NotificationType.SPLIT_KILL:
-                    result = JsonConvert.DeserializeObject<SplitKillNotification>(notificationData.Data);
+                    result = JsonConvert.DeserializeObject<SplitKillNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
                     break;
                 case NotificationType.SEGMENT_UPDATE:
-                    result = JsonConvert.DeserializeObject<SegmentChangeNotification>(notificationData.Data);
+                    result = JsonConvert.DeserializeObject<SegmentChangeNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
                     break;
                 default:
                     return null;
@@ -83,7 +85,7 @@ namespace Splitio.Services.EventSource
 
             if (notificationData.Data.Contains("controlType"))
             {
-                var controlNotification = JsonConvert.DeserializeObject<ControlNotification>(notificationData.Data);
+                var controlNotification = JsonConvert.DeserializeObject<ControlNotification>(notificationData.Data, SerializerSettings.DefaultSerializerSettings);
                 controlNotification.Type = NotificationType.CONTROL;
                 controlNotification.Channel = channel;
 
@@ -95,7 +97,7 @@ namespace Splitio.Services.EventSource
 
         private static IncomingNotification ParseOccupancy(string payload, string channel)
         {
-            var occupancyNotification = JsonConvert.DeserializeObject<OccupancyNotification>(payload);
+            var occupancyNotification = JsonConvert.DeserializeObject<OccupancyNotification>(payload, SerializerSettings.DefaultSerializerSettings);
 
             if (occupancyNotification?.Metrics == null)
                 return null;
@@ -124,7 +126,7 @@ namespace Splitio.Services.EventSource
             var index = Array.FindIndex(notificationArray, row => row.Contains("data:"));
             var data = notificationArray[index].Replace("data:", string.Empty);
 
-            return JsonConvert.DeserializeObject<T>(data.Trim());
+            return JsonConvert.DeserializeObject<T>(data.Trim(), SerializerSettings.DefaultSerializerSettings);
         }
 
         private T DecompressData<T>(InstantUpdateNotification notification) where T : class
@@ -159,7 +161,7 @@ namespace Splitio.Services.EventSource
 
         private static T DeserializeObject<T>(byte[] input)
         {
-            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(input));
+            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(input), SerializerSettings.DefaultSerializerSettings);
         }
     }
 }

--- a/src/Splitio/Services/Impressions/Classes/ImpressionsSdkApiClient.cs
+++ b/src/Splitio/Services/Impressions/Classes/ImpressionsSdkApiClient.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Splitio.Common;
 
 namespace Splitio.Services.Impressions.Classes
 {
@@ -82,12 +83,12 @@ namespace Splitio.Services.Impressions.Classes
                 .GroupBy(item => item.feature)
                 .Select(group => new { f = group.Key, i = group.Select(x => new { k = x.keyName, t = x.treatment, m = x.time, c = x.changeNumber, r = x.label, b = x.bucketingKey }) });
 
-            return JsonConvert.SerializeObject(impressionsPerFeature);
+            return JsonConvert.SerializeObject(impressionsPerFeature, SerializerSettings.DefaultSerializerSettings);
         }
 
         public static string ConvertToJson(List<ImpressionsCountModel> impressionsCount)
         {
-            return JsonConvert.SerializeObject(new { pf = impressionsCount });
+            return JsonConvert.SerializeObject(new { pf = impressionsCount }, SerializerSettings.DefaultSerializerSettings);
         }
 
         private async Task BuildJsonAndPostAsync(List<KeyImpression> impressions, Util.SplitStopwatch clock)

--- a/src/Splitio/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
@@ -3,6 +3,8 @@ using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.Threading.Tasks;
+using Splitio.Common;
+using Splitio.Services.Common;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -19,7 +21,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
         {
             var fetchResult = await _apiClient.FetchSegmentChangesAsync(name, since, fetchOptions);
 
-            return JsonConvert.DeserializeObject<SegmentChange>(fetchResult);
+            return JsonConvert.DeserializeObject<SegmentChange>(fetchResult, SerializerSettings.DefaultSerializerSettings);
         }
     }
 }

--- a/src/Splitio/Services/SegmentFetcher/Classes/JSONFileSegmentFetcher.cs
+++ b/src/Splitio/Services/SegmentFetcher/Classes/JSONFileSegmentFetcher.cs
@@ -3,6 +3,8 @@ using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using System.Collections.Generic;
 using System.IO;
+using Splitio.Common;
+using Splitio.Services.Common;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -16,7 +18,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             if (!string.IsNullOrEmpty(filePath))
             {
                 var json = File.ReadAllText(filePath);
-                var segmentChangesResult = JsonConvert.DeserializeObject<SegmentChange>(json);
+                var segmentChangesResult = JsonConvert.DeserializeObject<SegmentChange>(json, SerializerSettings.DefaultSerializerSettings);
                 added = segmentChangesResult.added;
             }
         }

--- a/src/Splitio/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
@@ -3,6 +3,8 @@ using Splitio.Constants;
 using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.Threading.Tasks;
+using Splitio.Common;
+using Splitio.Services.Common;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -25,12 +27,12 @@ namespace Splitio.Services.SplitFetcher.Classes
 
             if (result.Spec.Equals(ApiVersions.Spec1_1))
             {
-                var featureFlags = JsonConvert.DeserializeObject<OldSplitChangesDto>(result.Content);
+                var featureFlags = JsonConvert.DeserializeObject<OldSplitChangesDto>(result.Content, SerializerSettings.DefaultSerializerSettings);
 
                 return featureFlags.ToTargetingRulesDto(result.ClearCache);
             }
 
-            var targetingRulesDto = JsonConvert.DeserializeObject<TargetingRulesDto>(result.Content);
+            var targetingRulesDto = JsonConvert.DeserializeObject<TargetingRulesDto>(result.Content, SerializerSettings.DefaultSerializerSettings);
             targetingRulesDto.ClearCache = result.ClearCache;
             
             return targetingRulesDto;

--- a/src/Splitio/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
+++ b/src/Splitio/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
@@ -3,6 +3,8 @@ using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.IO;
 using System.Threading.Tasks;
+using Splitio.Common;
+using Splitio.Services.Common;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -18,13 +20,13 @@ namespace Splitio.Services.SplitFetcher.Classes
         protected override Task<TargetingRulesDto> FetchFromBackendAsync(FetchOptions fetchOptions)
         {
             var json = File.ReadAllText(_filePath);
-            var targetingRulesDto = JsonConvert.DeserializeObject<TargetingRulesDto>(json);
+            var targetingRulesDto = JsonConvert.DeserializeObject<TargetingRulesDto>(json, SerializerSettings.DefaultSerializerSettings);
             if (targetingRulesDto != null)
             {
                 return Task.FromResult(targetingRulesDto);
             }
 
-            var splitsResult = JsonConvert.DeserializeObject<OldSplitChangesDto>(json);
+            var splitsResult = JsonConvert.DeserializeObject<OldSplitChangesDto>(json, SerializerSettings.DefaultSerializerSettings);
 
             return Task.FromResult(splitsResult.ToTargetingRulesDto());
         }


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?

Added Default Serializer Settings so serializations are unaffected by [Default serializer settings](https://www.newtonsoft.com/json/help/html/DefaultSettings.htm).

We use snake case serialization by default, causing issues when deserializing and parsing results from Split API backend.

## How do we test the changes introduced in this PR?

No functional change - but could probably add coverage to test default serializer settings for one case to avoid regression.

## Extra Notes